### PR TITLE
Add categories carousel feature

### DIFF
--- a/src/AllPosts/AllPosts.jsx
+++ b/src/AllPosts/AllPosts.jsx
@@ -2,10 +2,12 @@ import Navbar from "../components/Navbar/Navbar.jsx";
 import Footer from "../components/Footer/Footer.jsx";
 import FeaturedBlogPostCard from "../components/FeaturedBlogPostCard/FeaturedBlogPostCard.jsx";
 import BlogPostCard from "../components/BlogPostCard/BlogPostCard.jsx";
+import Carousel from "./components/Carousel/Carousel.jsx";
 
 import { Pagination, Icon } from "semantic-ui-react";
 
 import dummyData from "../data/dummy-adventures.json";
+
 import "./AllPosts.scss";
 
 function AllPosts(props) {
@@ -17,6 +19,7 @@ function AllPosts(props) {
       <div className="all-posts-content">
         <div className="categories-section">
           <div className="section-title">Categories</div>
+          <Carousel {...props} />
         </div>
 
         <div className="adventures-section">

--- a/src/AllPosts/components/Carousel/Carousel.jsx
+++ b/src/AllPosts/components/Carousel/Carousel.jsx
@@ -44,7 +44,6 @@ function Carousel(props) {
   };
 
   return (
-    //make icon change to name=circle if in view
     <div className="carousel-wrapper">
       <div className="category-slider">
         <Button icon="angle left" onClick={onBackwardClick} />

--- a/src/AllPosts/components/Carousel/Carousel.jsx
+++ b/src/AllPosts/components/Carousel/Carousel.jsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import { Button, Icon, Image } from "semantic-ui-react";
+
+import dummyCategories from "../../../data/dummy-categories.json";
+
+import "./Carousel.scss";
+
+function Carousel(props) {
+  const [categoriesInView, setCategoriesInView] = useState(0);
+  const [circleIconOne, setCircleIconOne] = useState("circle");
+  const [circleIconTwo, setCircleIconTwo] = useState("circle outline");
+
+  useEffect(() => {
+    const handleCircleIcon = () => {
+      if (categoriesInView > 3) {
+        setCircleIconOne("circle outline");
+        setCircleIconTwo("circle");
+      } else if (categoriesInView >= 0 && categoriesInView <= 3) {
+        setCircleIconOne("circle");
+        setCircleIconTwo("circle outline");
+      }
+    };
+    handleCircleIcon();
+  }, [categoriesInView]);
+
+  const onForwardClick = () => {
+    if (categoriesInView < dummyCategories.length - 4) {
+      setCategoriesInView(categoriesInView + 1);
+    }
+  };
+
+  const onBackwardClick = () => {
+    if (categoriesInView > 0) {
+      setCategoriesInView(categoriesInView - 1);
+    }
+  };
+
+  const onCircleIconOneClick = () => {
+    setCategoriesInView(0);
+  };
+
+  const onCircleIconTwoClick = () => {
+    setCategoriesInView(4);
+  };
+
+  return (
+    //make icon change to name=circle if in view
+    <div className="carousel-wrapper">
+      <div className="category-slider">
+        <Button icon="angle left" onClick={onBackwardClick} />
+        <div className="categories-container">
+          {dummyCategories.map((category, index) => {
+            if (index >= categoriesInView && index < categoriesInView + 4) {
+              return (
+                <div className="category-container" key={index}>
+                  <Image src={category.image} size="tiny" />
+                  <div className="image-overlay">
+                    <div className="image-text">
+                      <div className="category-name">{category.label}</div>
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+          })}
+        </div>
+        <Button icon="angle right" onClick={onForwardClick} />
+      </div>
+      <Button.Group icon>
+        <Button onClick={onCircleIconOneClick}>
+          <Icon name={circleIconOne} />
+        </Button>
+        <Button onClick={onCircleIconTwoClick}>
+          <Icon name={circleIconTwo} />
+        </Button>
+      </Button.Group>
+    </div>
+  );
+}
+
+export default Carousel;

--- a/src/AllPosts/components/Carousel/Carousel.scss
+++ b/src/AllPosts/components/Carousel/Carousel.scss
@@ -1,0 +1,78 @@
+.carousel-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .category-slider {
+    display: flex;
+    flex-direction: row;
+
+    .categories-container {
+      display: flex;
+      flex-direction: row;
+      width: 83vw;
+
+      .category-container {
+        position: relative;
+        margin-right: 0.25em;
+
+        .ui.image {
+          display: block;
+          width: 100%;
+          height: auto;
+        }
+
+        .image-overlay {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          height: 100%;
+          width: 100%;
+          opacity: 1;
+          background-color: #0000009f;
+        }
+
+        .image-text {
+          color: white;
+          position: absolute;
+
+          top: 50%;
+          left: 50%;
+          -webkit-transform: translate(-50%, -50%);
+          -ms-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
+          text-align: center;
+        }
+
+        .category-name {
+          color: white;
+          font-size: 25px;
+          position: absolute;
+          line-height: 1.25em;
+          top: 50%;
+          left: 50%;
+          -webkit-transform: translate(-50%, -50%);
+          -ms-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  .ui.icon.button:hover {
+    background-color: white;
+  }
+
+  .ui.button {
+    box-shadow: none;
+    background-color: white;
+  }
+
+  .ui.button:hover {
+    background-color: white;
+  }
+}

--- a/src/SinglePost/SinglePost.jsx
+++ b/src/SinglePost/SinglePost.jsx
@@ -46,14 +46,18 @@ function SinglePost(props) {
         <div>
           {blogPostData.body.map((item, index) => {
             return (
-              <div className="post-body-container">
+              <div className="post-body-container" key={index}>
                 <div className="post-text-container">
                   <div className="body-title">{item.body_title}</div>
                   <div className="body-text">{item.body}</div>
                 </div>
                 <div className="post-image-container">
                   {item.images.map((image, index) => {
-                    return <img src={image.src} className="post-image" />;
+                    return (
+                      <div key={index}>
+                        <img src={image.src} className="post-image" />
+                      </div>
+                    );
                   })}
                 </div>
               </div>

--- a/src/data/dummy-adventures.json
+++ b/src/data/dummy-adventures.json
@@ -1,6 +1,16 @@
 [
     {
         "id": 8,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Europe",
+            "North America",
+            "Adventures Close to Home",
+            "Film",
+            "Food"
+        ],
         "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
         "title": "Kyoto - Part 1",
         "sub_title": "explored the streets of Kyoto",
@@ -32,18 +42,19 @@
             "Kyoto",
             "Japan",
             "subway"
-        ],
-        "categories": [
-            "Travel",
-            "Film",
-            "Activities",
-            "Japan",
-            "South Korea",
-            "Adventures Close to Home"
         ]
     },
     {
         "id": 9,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Europe",
+            "North America",
+            "Adventures Close to Home",
+            "Film"
+        ],
         "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
         "title": "Adventures in Seoul - Part 1",
         "sub_title": "portra 400",
@@ -75,11 +86,19 @@
             "Seoul",
             "Hike",
             "Seoul Tower"
-        ],
-        "categories": []
+        ]
     },
     {
         "id": 10,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Europe",
+            "North America",
+            "Adventures Close to Home",
+            "Film"
+        ],
         "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
         "title": "Kyoto - Part 2",
         "sub_title": "portra 400",
@@ -111,11 +130,19 @@
             "kyoto",
             "japan",
             "subway"
-        ],
-        "categories": []
+        ]
     },
     {
         "id": 11,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Europe",
+            "North America",
+            "Adventures Close to Home",
+            "Film"
+        ],
         "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
         "title": "Kyoto - Part 3",
         "sub_title": "explored the streets of Kyoto",
@@ -147,8 +174,7 @@
             "Kyoto",
             "Japan",
             "subway"
-        ],
-        "categories": []
+        ]
     }
 
 ]

--- a/src/data/dummy-categories.json
+++ b/src/data/dummy-categories.json
@@ -1,0 +1,34 @@
+[
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Travel"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Activities"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Asia"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Europe"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "North America"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Adventures Close to Home"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Film"
+  },
+  {
+    "image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "label": "Food"
+  }
+]

--- a/src/data/dummy-tags.json
+++ b/src/data/dummy-tags.json
@@ -1,0 +1,5 @@
+[
+  "Kyoto",
+  "Japan",
+  "subway"
+]


### PR DESCRIPTION
# Description

This feature adds a carousel of blog post categories to the '/adventures' page. This is a base structure allowing the user to navigate through the carousel. The user uses buttons that move through the carousel forward, backward, and in sets of 4. This feature also adds two dummy json files for the categories and future tags.

# Testing 

Navigate to the '/adventures' page. 
There are a total of 8 categories. The first is Travel and the last is Food.

1. Click on the forward ">" button to confirm it moves forward through the categories once each click. The first circle icon should be outlined and second circle icon should be filled when the final category Food is visible. 
2. Click on the backward "<" button to confirm it moves backward through the categories once each click. The first circle icon should be filled and second circle icon should be outlined when the final category Food is no longer visible. 
3. Click the circle icons to confirm the first renders the categories Travel through Europe and the second renders the categories North America through Food. 

# Other Notes

The category images will be clickable in the future so the user can search and filter through blog posts based on the category. 