### PR TITLE
Update number of posts shown per page and pages scroll to top on render

### DIFF
--- a/src/Admin/Admin.jsx
+++ b/src/Admin/Admin.jsx
@@ -10,7 +10,6 @@ import EditPhotography from "./components/ManagePhotography/EditPhotography/Edit
 import "./Admin.scss";
 
 function Admin(props) {
-  //change default state, setting for testing
   const [activeMenuItem, setActiveMenuItem] = useState("dashboard");
 
   const handleActiveComponent = () => {

--- a/src/AllPosts/AllPosts.jsx
+++ b/src/AllPosts/AllPosts.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 
 import Navbar from "../components/Navbar/Navbar.jsx";
 import Footer from "../components/Footer/Footer.jsx";
-import FeaturedBlogPostCard from "../components/FeaturedBlogPostCard/FeaturedBlogPostCard.jsx";
 import BlogPostCard from "../components/BlogPostCard/BlogPostCard.jsx";
 import Carousel from "./components/Carousel/Carousel.jsx";
 
@@ -14,7 +13,8 @@ import "./AllPosts.scss";
 
 function AllPosts(props) {
   const [adventureData, setAdventureData] = useState([]);
-  const [latestPost = {}, ...posts] = adventureData;
+  const [currentPage, setCurrentPage] = useState(1);
+  const posts = adventureData;
 
   useEffect(async () => {
     setAdventureData(await getAdventures());
@@ -31,25 +31,34 @@ function AllPosts(props) {
 
         <div className="adventures-section">
           <div className="section-title">Adventures</div>
-          <FeaturedBlogPostCard latestPost={latestPost} {...props} />
           <div className="blog-post-container">
-            {posts.map((item, index) => {
-              return (
-                <div className="blog-post-card-div" key={index}>
-                  <BlogPostCard blogPostData={item} index={index} {...props} />
-                </div>
-              );
-            })}
+            {posts
+              .slice((currentPage - 1) * 9, (currentPage - 1) * 9 + 9)
+              .map((item, index) => {
+                return (
+                  <div className="blog-post-card-div" key={index}>
+                    <BlogPostCard
+                      blogPostData={item}
+                      index={index}
+                      {...props}
+                    />
+                  </div>
+                );
+              })}
           </div>
         </div>
       </div>
       <Pagination
-        defaultActivePage={1}
+        activePage={currentPage}
+        onPageChange={(event, data) => {
+          setCurrentPage(data.activePage);
+          window.scrollTo(0, 0);
+        }}
         firstItem={{ content: <Icon name="angle double left" />, icon: true }}
         lastItem={{ content: <Icon name="angle double right" />, icon: true }}
         pointing
         secondary
-        totalPages={3}
+        totalPages={posts.length / 9}
       />
       <Footer />
     </div>

--- a/src/Home/Home.jsx
+++ b/src/Home/Home.jsx
@@ -46,22 +46,27 @@ function Home(props) {
             <FeaturedBlogPostCard latestPost={latestPost} {...props} />
             <div className="blog-post-container">
               {posts.map((item, index) => {
-                return (
-                  <div className="blog-post-card-div" key={index}>
-                    <BlogPostCard
-                      blogPostData={item}
-                      index={index}
-                      {...props}
-                    />
-                  </div>
-                );
+                if (index <= 5) {
+                  return (
+                    <div className="blog-post-card-div" key={index}>
+                      <BlogPostCard
+                        blogPostData={item}
+                        index={index}
+                        {...props}
+                      />
+                    </div>
+                  );
+                }
               })}
             </div>
           </div>
           <div className="see-more">
             <Button
               className="see-more-button"
-              onClick={() => props.history.push("/adventures")}
+              onClick={() => {
+                props.history.push("/adventures");
+                window.scrollTo(0, 0);
+              }}
             >
               More Adventures
             </Button>
@@ -71,7 +76,7 @@ function Home(props) {
             <div className="section-title">Recent Photography</div>
             <div className="photo-images-container">
               {photoData.map((item, index) => {
-                if (index <= 3) {
+                if (index <= 5) {
                   return (
                     <div key={index}>
                       <PhotographyImage
@@ -89,7 +94,10 @@ function Home(props) {
           <div className="see-more">
             <Button
               className="see-more-button"
-              onClick={() => props.history.push("/photography")}
+              onClick={() => {
+                props.history.push("/photography");
+                window.scrollTo(0, 0);
+              }}
             >
               More Photogragphy
             </Button>

--- a/src/Photography/Photography.jsx
+++ b/src/Photography/Photography.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 import Navbar from "../components/Navbar/Navbar.jsx";
 import Footer from "../components/Footer/Footer.jsx";
@@ -7,6 +7,7 @@ import PhotographyImage from "../components/PhotographyImage/PhotographyImage.js
 import { getPhotos } from "../api.js";
 
 import "./Photography.scss";
+import { Button, Icon, Ref, Sticky, Rail } from "semantic-ui-react";
 
 function Photography(props) {
   const [photoData, setPhotoData] = useState([]);
@@ -15,26 +16,41 @@ function Photography(props) {
     setPhotoData(await getPhotos());
   }, []);
 
+  const refContainer = useRef(null);
+
   return (
     <div className="photography-container">
       <Navbar {...props} />
-      <div className="photography-content">
-        <div className="photography-header">Photogragphy Archive</div>
-        <div className="photo-images-container">
-          {photoData.map((item, index) => {
-            return (
-              <div key={index}>
-                <PhotographyImage
-                  photoData={item}
-                  index={index}
-                  {...props}
-                  size="big"
-                />
-              </div>
-            );
-          })}
+      <Ref innerRef={refContainer}>
+        <div className="photography-content">
+          <div className="photography-header">Photogragphy Archive</div>
+          <div className="photo-images-container">
+            {photoData.map((item, index) => {
+              return (
+                <div key={index}>
+                  <PhotographyImage
+                    photoData={item}
+                    index={index}
+                    {...props}
+                    size="big"
+                  />
+                </div>
+              );
+            })}
+          </div>
+          <Rail internal position="right">
+            <Sticky context={refContainer} pushing>
+              <Button
+                icon
+                className="return-to-top"
+                onClick={() => window.scrollTo(0, 0)}
+              >
+                <Icon name="angle double up" />
+              </Button>
+            </Sticky>
+          </Rail>
         </div>
-      </div>
+      </Ref>
       <Footer />
     </div>
   );

--- a/src/Photography/Photography.scss
+++ b/src/Photography/Photography.scss
@@ -25,4 +25,16 @@
       }
     }
   }
+  .ui.icon.button.return-to-top {
+    margin: 1em;
+    padding: 0.75em 1em 0.75em 1em;
+    font-size: 1.5em;
+    background-color: #0b090a;
+    color: #ffffff;
+  }
+  .ui.rail {
+    display: flex;
+    width: 10vw;
+    align-items: flex-end;
+  }
 }

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 
 import Home from "./Home/Home.jsx";
@@ -7,9 +8,13 @@ import About from "./About/About.jsx";
 import SinglePost from "./SinglePost/SinglePost.jsx";
 import Search from "./Search/Search.jsx";
 import Admin from "./Admin/Admin.jsx";
-import AdminLogin from "./Admin/AdminLogin//AdminLogin.jsx";
+import AdminLogin from "./Admin/AdminLogin/AdminLogin.jsx";
 
 function Routes(props) {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <Router>
       <Switch>

--- a/src/Search/Search.jsx
+++ b/src/Search/Search.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { get, isEmpty } from "lodash";
-import { Dropdown, Icon } from "semantic-ui-react";
+import { Dropdown, Icon, Pagination } from "semantic-ui-react";
 
 import Navbar from "../components/Navbar/Navbar.jsx";
 import Footer from "../components/Footer/Footer.jsx";
@@ -25,14 +25,13 @@ function Search(props) {
   const [clearFiltersVisible, setClearFiltersVisible] = useState(false);
   const [applyFiltersVisible, setApplyFiltersVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(async () => {
     setAdventureData(await getAdventures());
   }, []);
 
   useEffect(async () => {
-    // if (!isEmpty(adventureData)) {
-    console.log(adventureData);
     if (get(props.location.state, "carouselCategory", undefined)) {
       const filterByCategory = adventureData.filter((blogPostData, index) =>
         blogPostData.categories.includes(
@@ -52,7 +51,6 @@ function Search(props) {
     } else {
       setSearchResult(adventureData);
     }
-    // }
   }, [
     get(props.location.state, "carouselCategory", undefined),
     get(props.location.state, "blogPostCardTag", undefined),
@@ -178,13 +176,11 @@ function Search(props) {
   };
 
   const onApplyFiltersClick = () => {
-    // if (clearFiltersVisible) {
     setIsCategoriesFilterActive(false);
     setFilterCategoryIcon("chevron down");
     setIsTagsFilterActive(false);
     setFilterTagIcon("chevron down");
     setApplyFiltersVisible(true);
-    // }
   };
 
   const removeSingleCategoryFilter = (category) => {
@@ -291,15 +287,29 @@ function Search(props) {
 
         {applyFilters()}
         <div className="search-result-container">
-          {searchResult.map((item, index) => {
-            return (
-              <div className="search-result" key={index}>
-                <BlogPostCard blogPostData={item} index={index} {...props} />
-              </div>
-            );
-          })}
+          {searchResult
+            .slice((currentPage - 1) * 9, (currentPage - 1) * 9 + 9)
+            .map((item, index) => {
+              return (
+                <div className="search-result" key={index}>
+                  <BlogPostCard blogPostData={item} index={index} {...props} />
+                </div>
+              );
+            })}
         </div>
       </div>
+      <Pagination
+        activePage={currentPage}
+        onPageChange={(event, data) => {
+          setCurrentPage(data.activePage);
+          window.scrollTo(0, 0);
+        }}
+        firstItem={{ content: <Icon name="angle double left" />, icon: true }}
+        lastItem={{ content: <Icon name="angle double right" />, icon: true }}
+        pointing
+        secondary
+        totalPages={searchResult.length / 9}
+      />
       <Footer />
     </div>
   );

--- a/src/Search/Search.scss
+++ b/src/Search/Search.scss
@@ -80,4 +80,7 @@
       display: flex;
     }
   }
+  .ui.secondary.pointing.menu {
+    margin: 0.4em;
+  }
 }

--- a/src/SinglePost/SinglePost.jsx
+++ b/src/SinglePost/SinglePost.jsx
@@ -49,7 +49,6 @@ function SinglePost(props) {
           adventure.categories.includes(category)
         )
     );
-    console.log(similarPosts);
     if (similarPosts.length > 0) {
       return (
         <div className="more-posts">

--- a/src/components/BlogPostCard/BlogPostCard.jsx
+++ b/src/components/BlogPostCard/BlogPostCard.jsx
@@ -29,17 +29,19 @@ function BlogPostCard(props) {
           <Image
             src={props.blogPostData.main_image}
             className="blog-post-card-img"
-            onClick={() =>
-              props.history.push("/post", { blogPostData: props.blogPostData })
-            }
+            onClick={() => {
+              props.history.push("/post", { blogPostData: props.blogPostData });
+              window.scrollTo(0, 0);
+            }}
             fluid
           />
         </div>
         <Card.Content className="blog-post-card-content-holder">
           <Card.Header
-            onClick={() =>
-              props.history.push("/post", { blogPostData: props.blogPostData })
-            }
+            onClick={() => {
+              props.history.push("/post", { blogPostData: props.blogPostData });
+              window.scrollTo(0, 0);
+            }}
           >
             {props.blogPostData.title}
           </Card.Header>
@@ -49,9 +51,10 @@ function BlogPostCard(props) {
           <Card.Description>{props.blogPostData.summary}</Card.Description>
           <div
             className="read-more"
-            onClick={() =>
-              props.history.push("/post", { blogPostData: props.blogPostData })
-            }
+            onClick={() => {
+              props.history.push("/post", { blogPostData: props.blogPostData });
+              window.scrollTo(0, 0);
+            }}
           >
             read more
             <Icon name="long arrow alternate right" size="large" />
@@ -62,9 +65,10 @@ function BlogPostCard(props) {
             <a
               className="tag-link"
               key={index}
-              onClick={() =>
-                props.history.push("/search", { blogPostCardTag: value })
-              }
+              onClick={() => {
+                props.history.push("/search", { blogPostCardTag: value });
+                window.scrollTo(0, 0);
+              }}
             >
               {value}
             </a>

--- a/src/components/FeaturedBlogPostCard/FeaturedBlogPostCard.jsx
+++ b/src/components/FeaturedBlogPostCard/FeaturedBlogPostCard.jsx
@@ -26,17 +26,19 @@ function FeaturedBlogPostCard(props) {
       <Image
         src={props.latestPost.main_image}
         className="featrued-card-img"
-        onClick={() =>
-          props.history.push("/post", { blogPostData: props.latestPost })
-        }
+        onClick={() => {
+          props.history.push("/post", { blogPostData: props.latestPost });
+          window.scrollTo(0, 0);
+        }}
       />
       <Card>
         <Card.Content>
           <Card.Header
             className="featured-title"
-            onClick={() =>
-              props.history.push("/post", { blogPostData: props.latestPost })
-            }
+            onClick={() => {
+              props.history.push("/post", { blogPostData: props.latestPost });
+              window.scrollTo(0, 0);
+            }}
           >
             {props.latestPost.title}
           </Card.Header>
@@ -46,9 +48,10 @@ function FeaturedBlogPostCard(props) {
           <Card.Description>{props.latestPost.summary}</Card.Description>
           <div
             className="read-more"
-            onClick={() =>
-              props.history.push("/post", { blogPostData: props.latestPost })
-            }
+            onClick={() => {
+              props.history.push("/post", { blogPostData: props.latestPost });
+              window.scrollTo(0, 0);
+            }}
           >
             read more
             <Icon name="long arrow alternate right" size="large" />
@@ -59,9 +62,10 @@ function FeaturedBlogPostCard(props) {
             <a
               className="tag-link"
               key={index}
-              onClick={() =>
-                props.history.push("/search", { blogPostCardTag: value })
-              }
+              onClick={() => {
+                props.history.push("/search", { blogPostCardTag: value });
+                window.scrollTo(0, 0);
+              }}
             >
               {value}
             </a>

--- a/src/data/dummy-adventures.json
+++ b/src/data/dummy-adventures.json
@@ -82,6 +82,46 @@
         ]
     },
     {
+        "id": 901,
+        "draft": true,
+        "categories": [  
+            "North America"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Adventures in Seoul - Part 1 copy testing",
+        "sub_title": "portra 400",
+        "date": "2019-10-06T18:54:47Z",
+        "date_posted":  "2020-10-06T18:54:47Z",
+        "summary": "adventuring around Seoul - took a walk to Seoul tower",
+        "post_section": [
+            {
+                "section_title":  "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Seoul",
+            "Hike",
+            "Seoul Tower"
+        ]
+    },
+    {
         "id": 10,
         "draft": false,
         "categories": [
@@ -124,6 +164,221 @@
             "Kyoto",
             "Japan",
             "subway"
+        ]
+    },
+    {
+        "id": 88,
+        "draft": true,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Kyoto - Part 1 copy test",
+        "sub_title": "explored the streets of Kyoto",
+        "date": "2018-10-05T18:54:47Z",
+        "date_posted":  "2020-10-05T18:54:47Z",
+        "summary": "adventuring around Kyoto - found an amazing ramen and a new favorite city words words words words lalallalal lalallalal lalalalla lalalalalla la",
+        "post_section": [
+            {
+                "section_title": "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Kyoto",
+            "Japan",
+            "subway"
+        ]
+    },
+    {
+        "id": 101,
+        "draft": false,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Europe",
+            "Adventures Close to Home",
+            "Film"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Kyoto - Part 2 copy test",
+        "sub_title": "portra 400",
+        "date": "2018-10-05T18:54:47Z",
+        "date_posted":  "2020-10-07T18:54:47Z",
+        "summary": "adventuring around Kyoto - walked all the steps and miles",
+        "post_section": [
+            {
+                "section_title":  "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Kyoto",
+            "Japan",
+            "subway"
+        ]
+    },
+    {
+        "id": 119,
+        "draft": true,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Adventures Close to Home",
+            "Film"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Kyoto - Part 3 copy test",
+        "sub_title": "explored the streets of Kyoto",
+        "date": "2018-10-05T18:54:47Z",
+        "date_posted":  "2020-10-10T18:54:47Z",
+        "summary": "adventuring around Kyoto - bamboo forest and tori gates",
+        "post_section": [
+            {
+                "section_title":  "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amaznaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Kyoto",
+            "Japan"
+        ]
+    },
+    {
+        "id": 856,
+        "draft": false,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Kyoto - Part 1 pagination",
+        "sub_title": "explored the streets of Kyoto",
+        "date": "2018-10-05T18:54:47Z",
+        "date_posted":  "2020-10-05T18:54:47Z",
+        "summary": "adventuring around Kyoto - found an amazing ramen and a new favorite city words words words words lalallalal lalallalal lalalalla lalalalalla la",
+        "post_section": [
+            {
+                "section_title": "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Kyoto",
+            "Japan",
+            "subway"
+        ]
+    },
+    {
+        "id": 1192,
+        "draft": true,
+        "categories": [
+            "Travel",
+            "Activities",
+            "Asia",
+            "Adventures Close to Home",
+            "Film"
+        ],
+        "main_image": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+        "title": "Kyoto - Part 3 copy testing",
+        "sub_title": "explored the streets of Kyoto",
+        "date": "2018-10-05T18:54:47Z",
+        "date_posted":  "2020-10-10T18:54:47Z",
+        "summary": "adventuring around Kyoto - bamboo forest and tori gates",
+        "post_section": [
+            {
+                "section_title":  "Adventure Title",
+                "section_text": "Yeah, I just moved it an inch every time he went to the bathroom. And that's how I spent my entire day that day, Pam. You can draw, kind of. Why don't you work with phallus on drawing a picture of the exposer that I can post around the community. It's a trap, a long story short, Jeff's dog ended up as ring bearer. And the irony is that, after the ceremony that dog peed on everything...and nobody said, 'Boo'. It was on company property, with company property. So, double jeopardy, we're fine. The dawn goosewalk will tug at your heartstrings, I would not miss it for the world, but if something else came up, I would definitely not go. There are ten rules of business that you need to learn. Number one: You need to play to win. But, you also have to.. win, to play, it was on company property, with company property. So, double jeopardy, we're fine, thus, Michael Scott sealed his own destiny... in a good way, I don't think-- I don't think you understand how jeopardy works.",
+                "images": [
+                    {
+                        "src": "https://adventures-archive.s3.amaznaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    },
+                    {
+                        "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+                        "date": "2018-10-05T18:54:47Z",
+                        "location": "kyoto, japan",
+                        "orientation": "portrait",
+                        "description": "film - porta 400"
+                    }
+                ]
+            }
+        ],
+        "tags": [
+            "Kyoto",
+            "Japan"
         ]
     },
     {

--- a/src/data/dummy-photos.json
+++ b/src/data/dummy-photos.json
@@ -42,11 +42,103 @@
       "orientation": "landscape"
   },
   {
-      "id": 13,
+    "id": 114,
+    "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "title": "Kyoto - Part 2",
+    "date": "2018-10-05T18:54:47Z",
+    "location": "Kyoto, Japan",
+    "orientation": "landscape"
+},
+{
+  "id": 165,
+  "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+  "title": "Kyoto - Part 2",
+  "date": "2018-10-05T18:54:47Z",
+  "location": "Kyoto, Japan",
+  "orientation": "landscape"
+},
+{
+  "id": 151,
+  "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+  "title": "Adventures in Seoul - Part 1",
+  "date": "2018-10-05T18:54:47Z",
+  "location": "Seoul, South Korea",
+  "orientation": "portrait"
+ },
+  {
+      "id": 1323,
+      "draft": true,
       "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
       "title": "Kyoto - Part 3",
       "date": "2018-10-05T18:54:47Z",
       "location": "Kyoto, Japan",
       "orientation": "landscape"
-  }
+      
+  },
+  {
+    "id": 823,
+    "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "title": "Kyoto - Part 1",
+    "date": "2018-10-05T18:54:47Z",
+    "location": "Kyoto, Japan",
+    "orientation": "landscape"
+},
+
+{
+  "id": 1023,
+  "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+  "title": "Adventures in Seoul - Part 1",
+  "date": "2018-10-05T18:54:47Z",
+  "location": "Seoul, South Korea",
+  "orientation": "portrait"
+ },
+
+ {
+  "id": 1123,
+  "src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+  "title": "Adventures in Seoul - Part 1",
+  "date": "2018-10-05T18:54:47Z",
+  "location": "Seoul, South Korea",
+  "orientation": "portrait"
+ },
+ {
+  "id": 923,
+  "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+  "title": "Adventures in Seoul - Part 1",
+  "date": "2019-10-06T18:54:47Z",
+  "location": "Kyoto, Japan",
+  "orientation": "landscape"
+ },
+{
+    "id": 1223,
+    "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+    "title": "Kyoto - Part 2",
+    "date": "2018-10-05T18:54:47Z",
+    "location": "Kyoto, Japan",
+    "orientation": "landscape"
+},
+{
+  "id": 11423,
+  "src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+  "title": "Kyoto - Part 2",
+  "date": "2018-10-05T18:54:47Z",
+  "location": "Kyoto, Japan",
+  "orientation": "landscape"
+},
+{
+"id": 16523,
+"src": "https://adventures-archive.s3.amazonaws.com/CB43046A-8A7E-400A-8E46-AB8759F8F197.JPG",
+"title": "Kyoto - Part 2",
+"date": "2018-10-05T18:54:47Z",
+"location": "Kyoto, Japan",
+"orientation": "landscape"
+},
+{
+"id": 15123,
+"src": "https://adventures-archive.s3.amazonaws.com/6B012524-418D-48BE-92E2-62A1DE23F6CB.JPG",
+"title": "Adventures in Seoul - Part 1",
+"date": "2018-10-05T18:54:47Z",
+"location": "Seoul, South Korea",
+"orientation": "portrait"
+}
 ]


### PR DESCRIPTION
## What 

This update will limit the number of posts shown on the adventures page and home page. It also makes the previously stood up paginations functional. Pages now render from the top of the page. A button was added to the infinite scroll Photography page to make it easier for users to return to the top of the page.